### PR TITLE
fix gameplay constructor

### DIFF
--- a/RenoBLL/src/main/java/pkgCore/GamePlay.java
+++ b/RenoBLL/src/main/java/pkgCore/GamePlay.java
@@ -67,6 +67,7 @@ public class GamePlay {
 	public GamePlay(Table t, Rule rle) {
 		GamePlayers.addAll(t.getTablePlayers());
 		GameDeck = new Deck();
+		this.rle = rle;
 	}
 
 	


### PR DESCRIPTION
i think this was missed in the constructor

students were having an issue with GamePlayTest. The method evaluate hands was trying to get the game rule, but it was never set, causing null pointer exceptions.